### PR TITLE
Make sure apps cannot forge package name on AssistStructure used for …

### DIFF
--- a/core/java/android/app/assist/AssistStructure.java
+++ b/core/java/android/app/assist/AssistStructure.java
@@ -2054,6 +2054,16 @@ public class AssistStructure implements Parcelable {
         return mActivityComponent;
     }
 
+    /**
+     * Called by Autofill server when app forged a different value.
+     *
+     * @hide
+     */
+    public void setActivityComponent(ComponentName componentName) {
+        ensureData();
+        mActivityComponent = componentName;
+    }
+
     /** @hide */
     public int getFlags() {
         return mFlags;

--- a/core/java/android/view/autofill/AutofillManager.java
+++ b/core/java/android/view/autofill/AutofillManager.java
@@ -24,6 +24,8 @@ import android.annotation.IntDef;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
 import android.annotation.SystemService;
+import android.app.Activity;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -43,6 +45,8 @@ import android.view.View;
 import com.android.internal.annotations.GuardedBy;
 import com.android.internal.logging.MetricsLogger;
 import com.android.internal.logging.nano.MetricsProto;
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.internal.util.Preconditions;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -326,7 +330,7 @@ public final class AutofillManager {
      * @hide
      */
     public AutofillManager(Context context, IAutoFillManager service) {
-        mContext = context;
+        mContext = Preconditions.checkNotNull(context, "context cannot be null");
         mService = service;
     }
 
@@ -832,6 +836,13 @@ public final class AutofillManager {
         return null;
     }
 
+    private ComponentName getComponentNameFromContext() {
+        if (mContext instanceof Activity) {
+            return ((Activity) mContext).getComponentName();
+        }
+        return null;
+    }
+
     /** @hide */
     public void onAuthenticationResult(int authenticationId, Intent data) {
         if (!hasAutofillFeature()) {
@@ -876,9 +887,14 @@ public final class AutofillManager {
         }
 
         try {
+            final ComponentName componentName = getComponentNameFromContext();
+            if (componentName == null) {
+                Log.w(TAG, "startSessionLocked(): context is not activity: " + mContext);
+                return;
+            }
             mSessionId = mService.startSession(mContext.getActivityToken(),
                     mServiceClient.asBinder(), id, bounds, value, mContext.getUserId(),
-                    mCallback != null, flags, mContext.getOpPackageName());
+                    mCallback != null, flags, componentName);
             final AutofillClient client = getClientLocked();
             if (client != null) {
                 client.autofillCallbackResetableStateAvailable();
@@ -929,9 +945,14 @@ public final class AutofillManager {
 
         try {
             if (restartIfNecessary) {
+                final ComponentName componentName = getComponentNameFromContext();
+                if (componentName == null) {
+                    Log.w(TAG, "startSessionLocked(): context is not activity: " + mContext);
+                    return;
+                }
                 final int newId = mService.updateOrRestartSession(mContext.getActivityToken(),
                         mServiceClient.asBinder(), id, bounds, value, mContext.getUserId(),
-                        mCallback != null, flags, mContext.getOpPackageName(), mSessionId, action);
+                        mCallback != null, flags, componentName, mSessionId, action);
                 if (newId != mSessionId) {
                     if (sDebug) Log.d(TAG, "Session restarted: " + mSessionId + "=>" + newId);
                     mSessionId = newId;

--- a/core/java/android/view/autofill/IAutoFillManager.aidl
+++ b/core/java/android/view/autofill/IAutoFillManager.aidl
@@ -16,6 +16,7 @@
 
 package android.view.autofill;
 
+import android.content.ComponentName;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.IBinder;
@@ -34,14 +35,15 @@ interface IAutoFillManager {
     int addClient(in IAutoFillManagerClient client, int userId);
     int startSession(IBinder activityToken, in IBinder appCallback, in AutofillId autoFillId,
             in Rect bounds, in AutofillValue value, int userId, boolean hasCallback, int flags,
-            String packageName);
+            in ComponentName componentName);
     FillEventHistory getFillEventHistory();
     boolean restoreSession(int sessionId, in IBinder activityToken, in IBinder appCallback);
     void updateSession(int sessionId, in AutofillId id, in Rect bounds,
             in AutofillValue value, int action, int flags, int userId);
     int updateOrRestartSession(IBinder activityToken, in IBinder appCallback,
             in AutofillId autoFillId, in Rect bounds, in AutofillValue value, int userId,
-            boolean hasCallback, int flags, String packageName, int sessionId, int action);
+            boolean hasCallback, int flags, in ComponentName componentName, int sessionId,
+            int action);
     void finishSession(int sessionId, int userId);
     void cancelSession(int sessionId, int userId);
     void setAuthenticationResult(in Bundle data, int sessionId, int authenticationId, int userId);

--- a/proto/src/metrics_constants.proto
+++ b/proto/src/metrics_constants.proto
@@ -3984,6 +3984,19 @@ message MetricsEvent {
     // OS: O
     FIELD_NOTIFICATION_GROUP_SUMMARY = 947;
 
+    // An app attempted to forge a different component name in the AssisStructure that would be
+    // passed to the autofill service.
+    // OS: O (security patch)
+    // Package: Real package of the app being autofilled
+    // Tag FIELD_AUTOFILL_SERVICE: Package of the autofill service that processed the request
+    // TAG FIELD_AUTOFILL_FORGED_COMPONENT_NAME: Component name being forged
+    AUTOFILL_FORGED_COMPONENT_ATTEMPT = 948;
+
+    // FIELD - The component that an app tried tro forged.
+    // Type: string
+    // OS: O (security patch)
+    FIELD_AUTOFILL_FORGED_COMPONENT_NAME = 949;
+
     // ---- End O Constants, all O constants go above this line ----
 
     // OPEN: Settings > System > Languages & input > Advanced > Lift to open camera
@@ -4218,6 +4231,11 @@ message MetricsEvent {
     // CATEGORY: SETTINGS
     // OS: O DR
     TRAMPOLINE_SETTINGS_EVENT = 1033;
+
+    // Autofill service called API that disables itself
+    // Package: Package of the autofill service
+    // OS: O MR
+    AUTOFILL_SERVICE_DISABLED_SELF = 1034;
 
     // ---- End O-DR1 Constants, all O-DR1 constants go above this line ----
 

--- a/services/autofill/java/com/android/server/autofill/AutofillManagerService.java
+++ b/services/autofill/java/com/android/server/autofill/AutofillManagerService.java
@@ -519,25 +519,26 @@ public final class AutofillManagerService extends SystemService {
         @Override
         public int startSession(IBinder activityToken, IBinder appCallback, AutofillId autofillId,
                 Rect bounds, AutofillValue value, int userId, boolean hasCallback, int flags,
-                String packageName) {
+                ComponentName componentName) {
 
             activityToken = Preconditions.checkNotNull(activityToken, "activityToken");
             appCallback = Preconditions.checkNotNull(appCallback, "appCallback");
             autofillId = Preconditions.checkNotNull(autofillId, "autoFillId");
-            packageName = Preconditions.checkNotNull(packageName, "packageName");
+            componentName = Preconditions.checkNotNull(componentName, "componentName");
+            final String packageName = Preconditions.checkNotNull(componentName.getPackageName());
 
             Preconditions.checkArgument(userId == UserHandle.getUserId(getCallingUid()), "userId");
 
             try {
                 mContext.getPackageManager().getPackageInfoAsUser(packageName, 0, userId);
             } catch (PackageManager.NameNotFoundException e) {
-                throw new IllegalArgumentException(packageName + " is not a valid package", e);
+                throw new IllegalArgumentException(componentName + " is not a valid package", e);
             }
 
             synchronized (mLock) {
                 final AutofillManagerServiceImpl service = getServiceForUserLocked(userId);
                 return service.startSessionLocked(activityToken, getCallingUid(), appCallback,
-                        autofillId, bounds, value, hasCallback, flags, packageName);
+                        autofillId, bounds, value, hasCallback, flags, componentName);
             }
         }
 
@@ -589,7 +590,8 @@ public final class AutofillManagerService extends SystemService {
         @Override
         public int updateOrRestartSession(IBinder activityToken, IBinder appCallback,
                 AutofillId autoFillId, Rect bounds, AutofillValue value, int userId,
-                boolean hasCallback, int flags, String packageName, int sessionId, int action) {
+                boolean hasCallback, int flags, ComponentName componentName, int sessionId,
+                int action) {
             boolean restart = false;
             synchronized (mLock) {
                 final AutofillManagerServiceImpl service = peekServiceForUserLocked(userId);
@@ -600,7 +602,7 @@ public final class AutofillManagerService extends SystemService {
             }
             if (restart) {
                 return startSession(activityToken, appCallback, autoFillId, bounds, value, userId,
-                        hasCallback, flags, packageName);
+                        hasCallback, flags, componentName);
             }
 
             // Nothing changed...

--- a/services/autofill/java/com/android/server/autofill/AutofillManagerServiceImpl.java
+++ b/services/autofill/java/com/android/server/autofill/AutofillManagerServiceImpl.java
@@ -32,8 +32,10 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ServiceInfo;
 import android.graphics.Rect;
+import android.metrics.LogMaker;
 import android.os.AsyncTask;
 import android.os.Binder;
 import android.os.Bundle;
@@ -61,6 +63,8 @@ import android.view.autofill.IAutoFillManagerClient;
 
 import com.android.internal.R;
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.logging.MetricsLogger;
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
 import com.android.internal.os.HandlerCaller;
 import com.android.server.autofill.ui.AutoFillUI;
 
@@ -87,6 +91,7 @@ final class AutofillManagerServiceImpl {
     private final Context mContext;
     private final Object mLock;
     private final AutoFillUI mUi;
+    private final MetricsLogger mMetricsLogger = new MetricsLogger();
 
     private RemoteCallbackList<IAutoFillManagerClient> mClients;
     private AutofillServiceInfo mInfo;
@@ -286,7 +291,7 @@ final class AutofillManagerServiceImpl {
     int startSessionLocked(@NonNull IBinder activityToken, int uid,
             @NonNull IBinder appCallbackToken, @NonNull AutofillId autofillId,
             @NonNull Rect virtualBounds, @Nullable AutofillValue value, boolean hasCallback,
-            int flags, @NonNull String packageName) {
+            int flags, @NonNull ComponentName componentName) {
         if (!isEnabled()) {
             return 0;
         }
@@ -295,7 +300,7 @@ final class AutofillManagerServiceImpl {
         pruneAbandonedSessionsLocked();
 
         final Session newSession = createSessionByTokenLocked(activityToken, uid, appCallbackToken,
-                hasCallback, packageName);
+                hasCallback, componentName);
         if (newSession == null) {
             return NO_SESSION;
         }
@@ -363,11 +368,14 @@ final class AutofillManagerServiceImpl {
         if (mInfo == null || mInfo.getServiceInfo().applicationInfo.uid != uid) {
             return;
         }
+        final ServiceInfo serviceInfo = mInfo.getServiceInfo();
         final long identity = Binder.clearCallingIdentity();
         try {
             final String autoFillService = getComponentNameFromSettings();
-            if (mInfo.getServiceInfo().getComponentName().equals(
-                    ComponentName.unflattenFromString(autoFillService))) {
+            final ComponentName componentName = serviceInfo.getComponentName();
+            if (componentName.equals(ComponentName.unflattenFromString(autoFillService))) {
+                mMetricsLogger.action(MetricsEvent.AUTOFILL_SERVICE_DISABLED_SELF,
+                        componentName.getPackageName());
                 Settings.Secure.putStringForUser(mContext.getContentResolver(),
                         Settings.Secure.AUTOFILL_SERVICE, null, mUserId);
                 destroySessionsLocked();
@@ -378,7 +386,8 @@ final class AutofillManagerServiceImpl {
     }
 
     private Session createSessionByTokenLocked(@NonNull IBinder activityToken, int uid,
-            @NonNull IBinder appCallbackToken, boolean hasCallback, @NonNull String packageName) {
+            @NonNull IBinder appCallbackToken, boolean hasCallback,
+            @NonNull ComponentName componentName) {
         // use random ids so that one app cannot know that another app creates sessions
         int sessionId;
         int tries = 0;
@@ -392,12 +401,41 @@ final class AutofillManagerServiceImpl {
             sessionId = sRandom.nextInt();
         } while (sessionId == NO_SESSION || mSessions.indexOfKey(sessionId) >= 0);
 
+        assertCallerLocked(componentName);
+
         final Session newSession = new Session(this, mUi, mContext, mHandlerCaller, mUserId, mLock,
                 sessionId, uid, activityToken, appCallbackToken, hasCallback,
-                mInfo.getServiceInfo().getComponentName(), packageName);
+                mInfo.getServiceInfo().getComponentName(), componentName);
         mSessions.put(newSession.id, newSession);
 
         return newSession;
+    }
+
+    /**
+     * Asserts the component is owned by the caller.
+     */
+    private void assertCallerLocked(@NonNull ComponentName componentName) {
+        final PackageManager pm = mContext.getPackageManager();
+        final int callingUid = Binder.getCallingUid();
+        final int packageUid;
+        try {
+            packageUid = pm.getPackageUidAsUser(componentName.getPackageName(),
+                    UserHandle.getCallingUserId());
+        } catch (NameNotFoundException e) {
+            throw new SecurityException("Could not verify UID for " + componentName);
+        }
+        if (callingUid != packageUid) {
+            final String[] packages = pm.getPackagesForUid(callingUid);
+            final String callingPackage = packages != null ? packages[0] : "uid-" + callingUid;
+            Slog.w(TAG, "App (package=" + callingPackage + ", UID=" + callingUid
+                    + ") passed component (" + componentName + ") owned by UID " + packageUid);
+            mMetricsLogger.write(new LogMaker(MetricsEvent.AUTOFILL_FORGED_COMPONENT_ATTEMPT)
+                    .setPackageName(callingPackage)
+                    .addTaggedData(MetricsEvent.FIELD_AUTOFILL_SERVICE, getPackageName())
+                    .addTaggedData(MetricsEvent.FIELD_AUTOFILL_FORGED_COMPONENT_NAME,
+                            componentName == null ? "null" : componentName.flattenToShortString()));
+            throw new SecurityException("Invalid component: " + componentName);
+        }
     }
 
     /**

--- a/services/autofill/java/com/android/server/autofill/Helper.java
+++ b/services/autofill/java/com/android/server/autofill/Helper.java
@@ -17,6 +17,7 @@
 package com.android.server.autofill;
 
 import android.annotation.Nullable;
+import android.metrics.LogMaker;
 import android.os.Bundle;
 import android.util.ArraySet;
 import android.view.autofill.AutofillId;
@@ -24,6 +25,8 @@ import android.view.autofill.AutofillId;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
 
 public final class Helper {
 
@@ -81,5 +84,14 @@ public final class Helper {
             array[i] = set.valueAt(i);
         }
         return array;
+    }
+
+    public static LogMaker newLogMaker(int category, String packageName,
+            String servicePackageName) {
+        final LogMaker log = new LogMaker(category).setPackageName(packageName);
+        if (servicePackageName != null) {
+            log.addTaggedData(MetricsEvent.FIELD_AUTOFILL_SERVICE, servicePackageName);
+        }
+        return log;
     }
 }

--- a/services/autofill/java/com/android/server/autofill/Session.java
+++ b/services/autofill/java/com/android/server/autofill/Session.java
@@ -119,8 +119,8 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
     @GuardedBy("mLock")
     @NonNull private IBinder mActivityToken;
 
-    /** Package name of the app that is auto-filled */
-    @NonNull private final String mPackageName;
+    /** Component that's being auto-filled */
+    @NonNull private final ComponentName mComponentName;
 
     @GuardedBy("mLock")
     private final ArrayMap<AutofillId, ViewState> mViewStates = new ArrayMap<>();
@@ -200,6 +200,16 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
                 structure.ensureData();
 
                 // Sanitize structure before it's sent to service.
+                final ComponentName componentNameFromApp = structure.getActivityComponent();
+                if (!mComponentName.equals(componentNameFromApp)) {
+                    Slog.w(TAG, "Activity " + mComponentName + " forged different component on "
+                            + "AssistStructure: " + componentNameFromApp);
+                    structure.setActivityComponent(mComponentName);
+                    mMetricsLogger.write(newLogMaker(MetricsEvent.AUTOFILL_FORGED_COMPONENT_ATTEMPT)
+                            .addTaggedData(MetricsEvent.FIELD_AUTOFILL_FORGED_COMPONENT_NAME,
+                                            componentNameFromApp == null ? "null"
+                                                    : componentNameFromApp.flattenToShortString()));
+                }
                 structure.sanitizeForParceling(true);
 
                 // Flags used to start the session.
@@ -350,20 +360,20 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
             @NonNull Context context, @NonNull HandlerCaller handlerCaller, int userId,
             @NonNull Object lock, int sessionId, int uid, @NonNull IBinder activityToken,
             @NonNull IBinder client, boolean hasCallback,
-            @NonNull ComponentName componentName, @NonNull String packageName) {
+            @NonNull ComponentName serviceComponentName, @NonNull ComponentName appComponentName) {
         id = sessionId;
         this.uid = uid;
         mService = service;
         mLock = lock;
         mUi = ui;
         mHandlerCaller = handlerCaller;
-        mRemoteFillService = new RemoteFillService(context, componentName, userId, this);
+        mRemoteFillService = new RemoteFillService(context, serviceComponentName, userId, this);
         mActivityToken = activityToken;
         mHasCallback = hasCallback;
-        mPackageName = packageName;
+        mComponentName = appComponentName;
         mClient = IAutoFillManagerClient.Stub.asInterface(client);
 
-        mMetricsLogger.action(MetricsEvent.AUTOFILL_SESSION_STARTED, mPackageName);
+        mMetricsLogger.action(MetricsEvent.AUTOFILL_SESSION_STARTED, mComponentName.getPackageName());
     }
 
     /**
@@ -432,7 +442,7 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
 
         final LogMaker log = (new LogMaker(MetricsEvent.AUTOFILL_REQUEST))
                 .setType(MetricsEvent.TYPE_SUCCESS)
-                .setPackageName(mPackageName)
+                .setPackageName(mComponentName.getPackageName())
                 .addTaggedData(MetricsEvent.FIELD_AUTOFILL_NUM_DATASETS,
                         response.getDatasets() == null ? 0 : response.getDatasets().size())
                 .addTaggedData(MetricsEvent.FIELD_AUTOFILL_SERVICE,
@@ -454,7 +464,7 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
         }
         LogMaker log = (new LogMaker(MetricsEvent.AUTOFILL_REQUEST))
                 .setType(MetricsEvent.TYPE_FAILURE)
-                .setPackageName(mPackageName)
+                .setPackageName(mComponentName.getPackageName())
                 .addTaggedData(MetricsEvent.FIELD_AUTOFILL_SERVICE, servicePackageName);
         mMetricsLogger.write(log);
 
@@ -477,7 +487,7 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
         LogMaker log = (new LogMaker(
                 MetricsEvent.AUTOFILL_DATA_SAVE_REQUEST))
                 .setType(MetricsEvent.TYPE_SUCCESS)
-                .setPackageName(mPackageName)
+                .setPackageName(mComponentName.getPackageName())
                 .addTaggedData(MetricsEvent.FIELD_AUTOFILL_SERVICE, servicePackageName);
         mMetricsLogger.write(log);
 
@@ -501,7 +511,7 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
         LogMaker log = (new LogMaker(
                 MetricsEvent.AUTOFILL_DATA_SAVE_REQUEST))
                 .setType(MetricsEvent.TYPE_FAILURE)
-                .setPackageName(mPackageName)
+                .setPackageName(mComponentName.getPackageName())
                 .addTaggedData(MetricsEvent.FIELD_AUTOFILL_SERVICE, servicePackageName);
         mMetricsLogger.write(log);
 
@@ -696,7 +706,7 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
         final Parcelable result = data.getParcelable(AutofillManager.EXTRA_AUTHENTICATION_RESULT);
         if (result instanceof FillResponse) {
             final FillResponse response = (FillResponse) result;
-            mMetricsLogger.action(MetricsEvent.AUTOFILL_AUTHENTICATED, mPackageName);
+            mMetricsLogger.action(MetricsEvent.AUTOFILL_AUTHENTICATED, mComponentName.getPackageName());
             replaceResponseLocked(authenticatedResponse, response);
         } else if (result instanceof Dataset) {
             if (datasetIdx != AutofillManager.AUTHENTICATION_ID_DATASET_ID_UNDEFINED) {
@@ -839,9 +849,8 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
             if (atLeastOneChanged) {
                 if (sDebug) Slog.d(TAG, "at least one field changed - showing save UI");
                 mService.setSaveShown(id);
-                getUiForShowing().showSaveUi(mService.getServiceLabel(), saveInfo, mPackageName,
+                getUiForShowing().showSaveUi(mService.getServiceLabel(), saveInfo, mComponentName.getPackageName(),
                         this);
-
                 mIsSaving = true;
                 return false;
             }
@@ -1151,8 +1160,8 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
         if (value != null && value.isText()) {
             filterText = value.getTextValue().toString();
         }
-
-        getUiForShowing().showFillUi(filledId, response, filterText, mPackageName, this);
+        getUiForShowing().showFillUi(filledId, response, filterText,
+            mComponentName.getPackageName(), this);
     }
 
     boolean isDestroyed() {
@@ -1417,14 +1426,14 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
 
     @Override
     public String toString() {
-        return "Session: [id=" + id + ", pkg=" + mPackageName + "]";
+        return "Session: [id=" + id + ", pkg=" + mComponentName.getPackageName() + "]";
     }
 
     void dumpLocked(String prefix, PrintWriter pw) {
         final String prefix2 = prefix + "  ";
         pw.print(prefix); pw.print("id: "); pw.println(id);
         pw.print(prefix); pw.print("uid: "); pw.println(uid);
-        pw.print(prefix); pw.print("mPackagename: "); pw.println(mPackageName);
+        pw.print(prefix); pw.print("mComponentName: "); pw.println(mComponentName);
         pw.print(prefix); pw.print("mActivityToken: "); pw.println(mActivityToken);
         pw.print(prefix); pw.print("mResponses: ");
         if (mResponses == null) {
@@ -1528,7 +1537,7 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
         hideAllUiIfOwnedByMe();
         mUi.clearCallback(this);
         mDestroyed = true;
-        mMetricsLogger.action(MetricsEvent.AUTOFILL_SESSION_FINISHED, mPackageName);
+        mMetricsLogger.action(MetricsEvent.AUTOFILL_SESSION_FINISHED, mComponentName.getPackageName());
         return mRemoteFillService;
     }
 
@@ -1574,5 +1583,12 @@ final class Session implements RemoteFillService.FillServiceCallbacks, ViewState
             }
         }
         return lastResponseIdx;
+    }
+
+    private LogMaker newLogMaker(int category) {
+        return newLogMaker(category, mService.getPackageName());
+    }
+    private LogMaker newLogMaker(int category, String servicePackageName) {
+        return Helper.newLogMaker(category, mComponentName.getPackageName(), servicePackageName);
     }
 }


### PR DESCRIPTION
…Autofill.

Test: cts-tradefed run commandAndExit cts-dev -m CtsAutoFillServiceTestCases -t android.autofillservice.cts.VirtualContainerActivityTest#testAppCannotFakePackageName
Test: cts-tradefed run commandAndExit cts-dev -m CtsAutoFillServiceTestCases

Bug: 69981710

Change-Id: Id6036cddb51dd8dd0c9128b7212d573f630d693f
Merged-In: Id6036cddb51dd8dd0c9128b7212d573f630d693f
(cherry picked from commit 23e61a9086a34405e277868474e003b37ed1b711)