### PR TITLE
DO NOT MERGE Truncate newline and tab characters in BluetoothDevice name

### DIFF
--- a/core/java/android/bluetooth/BluetoothDevice.java
+++ b/core/java/android/bluetooth/BluetoothDevice.java
@@ -808,8 +808,14 @@ public final class BluetoothDevice implements Parcelable {
             return null;
         }
         try {
-            return sService.getRemoteName(this);
-        } catch (RemoteException e) {Log.e(TAG, "", e);}
+            String name = sService.getRemoteName(this);
+            if (name != null) {
+                return name.replaceAll("[\\t\\n\\r]+", " ");
+            }
+            return null;
+        } catch (RemoteException e) {
+            Log.e(TAG, "", e);
+        }
         return null;
     }
 


### PR DESCRIPTION
Test: manual
Bug: 73173182
Change-Id: I7f2201cab36adf7f01d1a794d783cb78a536811f
(cherry picked from commit 24da173b63b17a0bc6c80b2fcfefa7fe4574a15b)