### PR TITLE
Fix crash during cursor moving on BiDi text

### DIFF
--- a/core/java/android/text/Layout.java
+++ b/core/java/android/text/Layout.java
@@ -1549,7 +1549,8 @@ public abstract class Layout {
         }
 
         float get(final int offset) {
-            if (mHorizontals == null) {
+            if (mHorizontals == null || offset < mLineStartOffset
+                    || offset >= mLineStartOffset + mHorizontals.length) {
                 return getPrimaryHorizontal(offset);
             } else {
                 return mHorizontals[offset - mLineStartOffset];


### PR DESCRIPTION
The crash was introduced by Ib66ef392c19c937718e7101f6d48fac3abe51ad0
The root cause of the crashing is requesting out-of-line access for the
horizontal width. This invalid access is silently ignored by
TextLine#measure() method but new implementation end up with out of
bounds access.

To makes behavior as old implementation, calling getHorizontal instead
of accessing measured result array.

Bug: 78464361, 111580019
Test: Manually done
Change-Id: I5c5778718f6b397adbb1e4f2cf95e9f635f6e5c8
(cherry picked from commit 960647d582911ae7ab8b9491097898e6c313aaf1)
Merged-In: I5c5778718f6b397adbb1e4f2cf95e9f635f6e5c8
(cherry picked from commit a1076fdaa54ebf56bb32bea43fb278f7470ff307)