### PR TITLE
SystemUI: don't crash without VRManager

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -948,7 +948,7 @@ public class StatusBar extends SystemUI implements DemoMode,
                 Context.VR_SERVICE));
         try {
             vrManager.registerListener(mVrStateCallbacks);
-        } catch (RemoteException e) {
+        } catch (RemoteException | NullPointerException e) {
             Slog.e(TAG, "Failed to register VR mode state listener: " + e);
         }
 


### PR DESCRIPTION
handle NullPointerException in case of config.disable_vrmanager=true