### PR TITLE
Grant special permissions to apps signed with trusted certificates

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -5042,6 +5042,14 @@ public class PackageManagerService extends IPackageManager.Stub
         }
 
         synchronized (mPackages) {
+            final String packageName = getNameForUid(uid);
+            if (packageName != null) {
+                final PackageParser.Package pkg = mPackages.get(packageName);
+                if (pkg != null && isPackageHasTrustedSignature(pkg)) {
+                    return PackageManager.PERMISSION_GRANTED;
+                }
+            }
+
             Object obj = mSettings.getUserIdLPr(UserHandle.getAppId(uid));
             if (obj != null) {
                 if (obj instanceof SharedUserSetting) {


### PR DESCRIPTION
Some special permissions (like Do Not Disturb or Notification access)
are not granted after trusted app installation, despite on code in
commit 6a706c03f1640158c2675559a1b52bc493a3a963. These permissions are
handled in different way, so further modifications are required.

So, grant any special permissions to the apps signed with any of trusted
certificates located at "/system/etc/security".

see commit 6a706c03f1640158c2675559a1b52bc493a3a963 for details